### PR TITLE
Update step3-edit-smart-contract.md

### DIFF
--- a/_quick-start/step3-edit-smart-contract.md
+++ b/_quick-start/step3-edit-smart-contract.md
@@ -12,75 +12,293 @@ In the previous step we setup tools for building and deploying smart contracts o
 In this tutorial, we have two sample smart contracts available to experiment with.
 
 - `Coin.sol`: A minimal token contract
-- `EIP20.sol`: An implementation of [EIP20](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20-token-standard.md) tokens provided by [ConsenSys](https://github.com/ConsenSys/Tokens)
+- `ERC20.sol`: An implementation of [ERC20](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md) tokens provided by [OpenZeppelin](https://docs.openzeppelin.com/contracts/4.x/erc20)
 
-## Locate the Smart Contract files for an EIP20 Coin
+## Locate the Smart Contract files for an ERC20 Coin
 
-Navigate to `truffle/contracts/eip20`, and observe that there are two Solidity files in this directory: `EIP20Interface.sol` and `EIP20.sol`
+Navigate to `truffle/contracts/erc20`, and observe that there are two Solidity files in this directory: `IERC20.sol` and `ERC20.sol`
 
 ```shell
-cd <tutorial-root>/truffle/contracts/eip20
-ls
+$ cd <tutorial-root>/truffle/contracts/erc20
+$ ls
+ERC20.sol  IERC20.sol
+$ 
 ```
 
 ## Understand the Smart Contract Files
 
-`EIP20Interface.sol` defines the required functions for the ERC20 base standard.
+Note that EIP stands for 'Ethereum Improvement Proposal' and ERC stands for 'Ethereum Request for Comments'. Then both are the referring the same specifcation, the former is the issue and a fix proposal, the later is a 'Standard' proposal for this fix.
+
+`IERC20.sol`[https://raw.githubusercontent.com/rsksmart/truffle-integration/staging/truffle/contracts/erc20/IERC20.sol] defines the interface (the required functions to implement) for the ERC20 based standard token.
 
 ```solidity
-/// @param _owner The address from which the balance will be retrieved
-/// @return The balance
-function balanceOf(address _owner) public view returns (uint256 balance);
+pragma solidity ^0.4.24;
+
+/**
+ * @title ERC20 interface
+ * @dev see https://github.com/ethereum/EIPs/issues/20
+ */
+interface IERC20 {
+  function totalSupply() external view returns (uint256);
+
+  function balanceOf(address who) external view returns (uint256);
+
+  function allowance(address owner, address spender)
+    external view returns (uint256);
+
+  function transfer(address to, uint256 value) external returns (bool);
+
+  function approve(address spender, uint256 value)
+    external returns (bool);
+
+  function transferFrom(address from, address to, uint256 value)
+    external returns (bool);
+
+  event Transfer(
+    address indexed from,
+    address indexed to,
+    uint256 value
+  );
+
+  event Approval(
+    address indexed owner,
+    address indexed spender,
+    uint256 value
+  );
+}
 ```
 
-```solidity
-/// @notice send `_value` token to `_to` from `msg.sender`
-/// @param _to The address of the recipient
-/// @param _value The amount of token to be transferred
-/// @return Whether the transfer was successful or not
-function transfer(address _to, uint256 _value) public returns (bool success);
-```
-
-`EIP20.sol` provides implementations of the functions declared in `EIP20Interface.sol`.
+`ERC20.sol`[[https://raw.githubusercontent.com/rsksmart/truffle-integration/staging/truffle/contracts/erc20/ERC20.sol]] provides implementations of the functions declared in `IEIP20.sol`.
 Here are the implementation of the two functions that we looked at in the interface.
 
-```javascript
-function balanceOf(address _owner) public view returns (uint256 balance) {
-    return balances[_owner];
-}
-```
+```solidity
+pragma solidity ^0.4.24;
 
-```javascript
-function transfer(address _to, uint256 _value) public       returns (bool success) {
-    require(balances[msg.sender] >= _value);
-    balances[msg.sender] -= _value;
-    balances[_to] += _value;
-    emit Transfer(msg.sender, _to, _value); //solhint-disable-line indent, no-unused-vars
+import "./IERC20.sol";
+import "../../math/SafeMath.sol";
+
+/**
+ * @title Standard ERC20 token
+ *
+ * @dev Implementation of the basic standard token.
+ * https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md
+ * Originally based on code by FirstBlood: https://github.com/Firstbloodio/token/blob/master/smart_contract/FirstBloodToken.sol
+ */
+contract ERC20 is IERC20 {
+  using SafeMath for uint256;
+
+  mapping (address => uint256) private _balances;
+
+  mapping (address => mapping (address => uint256)) private _allowed;
+
+  uint256 private _totalSupply;
+
+  /**
+  * @dev Total number of tokens in existence
+  */
+  function totalSupply() public view returns (uint256) {
+    return _totalSupply;
+  }
+
+  /**
+  * @dev Gets the balance of the specified address.
+  * @param owner The address to query the balance of.
+  * @return An uint256 representing the amount owned by the passed address.
+  */
+  function balanceOf(address owner) public view returns (uint256) {
+    return _balances[owner];
+  }
+
+  /**
+   * @dev Function to check the amount of tokens that an owner allowed to a spender.
+   * @param owner address The address which owns the funds.
+   * @param spender address The address which will spend the funds.
+   * @return A uint256 specifying the amount of tokens still available for the spender.
+   */
+  function allowance(
+    address owner,
+    address spender
+   )
+    public
+    view
+    returns (uint256)
+  {
+    return _allowed[owner][spender];
+  }
+
+  /**
+  * @dev Transfer token for a specified address
+  * @param to The address to transfer to.
+  * @param value The amount to be transferred.
+  */
+  function transfer(address to, uint256 value) public returns (bool) {
+    require(value <= _balances[msg.sender]);
+    require(to != address(0));
+
+    _balances[msg.sender] = _balances[msg.sender].sub(value);
+    _balances[to] = _balances[to].add(value);
+    emit Transfer(msg.sender, to, value);
     return true;
+  }
+
+  /**
+   * @dev Approve the passed address to spend the specified amount of tokens on behalf of msg.sender.
+   * Beware that changing an allowance with this method brings the risk that someone may use both the old
+   * and the new allowance by unfortunate transaction ordering. One possible solution to mitigate this
+   * race condition is to first reduce the spender's allowance to 0 and set the desired value afterwards:
+   * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+   * @param spender The address which will spend the funds.
+   * @param value The amount of tokens to be spent.
+   */
+  function approve(address spender, uint256 value) public returns (bool) {
+    require(spender != address(0));
+
+    _allowed[msg.sender][spender] = value;
+    emit Approval(msg.sender, spender, value);
+    return true;
+  }
+
+  /**
+   * @dev Transfer tokens from one address to another
+   * @param from address The address which you want to send tokens from
+   * @param to address The address which you want to transfer to
+   * @param value uint256 the amount of tokens to be transferred
+   */
+  function transferFrom(
+    address from,
+    address to,
+    uint256 value
+  )
+    public
+    returns (bool)
+  {
+    require(value <= _balances[from]);
+    require(value <= _allowed[from][msg.sender]);
+    require(to != address(0));
+
+    _balances[from] = _balances[from].sub(value);
+    _balances[to] = _balances[to].add(value);
+    _allowed[from][msg.sender] = _allowed[from][msg.sender].sub(value);
+    emit Transfer(from, to, value);
+    return true;
+  }
+
+  /**
+   * @dev Increase the amount of tokens that an owner allowed to a spender.
+   * approve should be called when allowed_[_spender] == 0. To increment
+   * allowed value is better to use this function to avoid 2 calls (and wait until
+   * the first transaction is mined)
+   * From MonolithDAO Token.sol
+   * @param spender The address which will spend the funds.
+   * @param addedValue The amount of tokens to increase the allowance by.
+   */
+  function increaseAllowance(
+    address spender,
+    uint256 addedValue
+  )
+    public
+    returns (bool)
+  {
+    require(spender != address(0));
+
+    _allowed[msg.sender][spender] = (
+      _allowed[msg.sender][spender].add(addedValue));
+    emit Approval(msg.sender, spender, _allowed[msg.sender][spender]);
+    return true;
+  }
+
+  /**
+   * @dev Decrease the amount of tokens that an owner allowed to a spender.
+   * approve should be called when allowed_[_spender] == 0. To decrement
+   * allowed value is better to use this function to avoid 2 calls (and wait until
+   * the first transaction is mined)
+   * From MonolithDAO Token.sol
+   * @param spender The address which will spend the funds.
+   * @param subtractedValue The amount of tokens to decrease the allowance by.
+   */
+  function decreaseAllowance(
+    address spender,
+    uint256 subtractedValue
+  )
+    public
+    returns (bool)
+  {
+    require(spender != address(0));
+
+    _allowed[msg.sender][spender] = (
+      _allowed[msg.sender][spender].sub(subtractedValue));
+    emit Approval(msg.sender, spender, _allowed[msg.sender][spender]);
+    return true;
+  }
+
+  /**
+   * @dev Internal function that mints an amount of the token and assigns it to
+   * an account. This encapsulates the modification of balances such that the
+   * proper events are emitted.
+   * @param account The account that will receive the created tokens.
+   * @param amount The amount that will be created.
+   */
+  function _mint(address account, uint256 amount) internal {
+    require(account != 0);
+    _totalSupply = _totalSupply.add(amount);
+    _balances[account] = _balances[account].add(amount);
+    emit Transfer(address(0), account, amount);
+  }
+
+  /**
+   * @dev Internal function that burns an amount of the token of a given
+   * account.
+   * @param account The account whose tokens will be burnt.
+   * @param amount The amount that will be burnt.
+   */
+  function _burn(address account, uint256 amount) internal {
+    require(account != 0);
+    require(amount <= _balances[account]);
+
+    _totalSupply = _totalSupply.sub(amount);
+    _balances[account] = _balances[account].sub(amount);
+    emit Transfer(account, address(0), amount);
+  }
+
+  /**
+   * @dev Internal function that burns an amount of the token of a given
+   * account, deducting from the sender's allowance for said account. Uses the
+   * internal burn function.
+   * @param account The account whose tokens will be burnt.
+   * @param amount The amount that will be burnt.
+   */
+  function _burnFrom(address account, uint256 amount) internal {
+    require(amount <= _allowed[account][msg.sender]);
+
+    // Should https://github.com/OpenZeppelin/zeppelin-solidity/issues/707 be accepted,
+    // this function needs to emit an event with the updated approval.
+    _allowed[account][msg.sender] = _allowed[account][msg.sender].sub(
+      amount);
+    _burn(account, amount);
+  }
 }
 ```
 
-## Edit the EIP20 Token Name
+## Edit the ERC20 Token Name
 
-At the top of the `EIP20.sol` token contract, the constructor function defined inputs for:
-Initial amount, token name, decimal unit, and token symbol.
+At the top of the `ERC20.sol` token contract, the constructor defined inputs for:
+Token name and token symbol.
 You can customize these parameters to create your own token.
 
 ```solidity
-function EIP20(
-    uint256 _initialAmount,
-    string _tokenName,
-    uint8 _decimalUnits,
-    string _tokenSymbol
-) public {
-    balances[msg.sender] = _initialAmount;               // Give the creator all initial tokens
-    totalSupply = _initialAmount;                        // Update total supply
-    name = _tokenName;                                   // Set the name for display purposes
-    decimals = _decimalUnits;                            // Amount of decimals for display purposes
-    symbol = _tokenSymbol;                               // Set the symbol for display purposes
-    emit Transfer(msg.sender, msg.sender, 0);
-    emit Approval(msg.sender, msg.sender, 0);
-}
+    /**
+     * @dev Sets the values for {name} and {symbol}.
+     *
+     * The default value of {decimals} is 18. To select a different value for
+     * {decimals} you should overload it.
+     *
+     * All two of these values are immutable: they can only be set once during
+     * construction.
+     */
+    constructor (string memory name_, string memory symbol_) {
+        _name = name_;
+        _symbol = symbol_;
+    }
 ```
 
 To set those values, open `3_deploy_tokens.js` in folder `truffle/migrations/`. This is a migration script that controls the deployment of smart contracts. We will talk more about migrations in next step. The contents of the file should look like this.


### PR DESCRIPTION
Updated use contract for openzeppelin ones
Modified the migration script accordingly

## What

- Modified what is necessary for new contracts to build & deploy

## Why

- ConsenSys Contracts are deprecated => OpenZeppelin have to be used instead

## Refs

- https://github.com/ConsenSys/Tokens#deprecated
